### PR TITLE
:robot: Add github-actions as a package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 updates:
   - directory: "/"
+    package-ecosystem: "github-actions"
+    open-pull-requests-limit: 16
+    schedule:
+      interval: "daily"
+  - directory: "/"
     package-ecosystem: "npm"
     open-pull-requests-limit: 16
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
-version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - directory: "/"
+    package-ecosystem: "npm"
     open-pull-requests-limit: 16
     schedule:
       interval: "daily"
     target-branch: npm-and-yarn
+version: 2


### PR DESCRIPTION
This PR adds 'github-actions' as a package ecosystem to dependabot.

<details>
<summary>Commits</summary>

- https://github.com/kei-g/emojify-js/commit/9aa4e3707200eaf902073e73f2ed8e874dd2a2f8 :robot: Arrange fields by ascending order
- https://github.com/kei-g/emojify-js/commit/f1a726c3a76983fc0c8aba8134d1139427177baa :robot: Add 'github-actions' as a package ecosystem
</details>