### PR TITLE
:robot: Specify target branch to 'ci' for 'github-actions' ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     open-pull-requests-limit: 16
     schedule:
       interval: "daily"
+    target-branch: ci
   - directory: "/"
     package-ecosystem: "npm"
     open-pull-requests-limit: 16


### PR DESCRIPTION
This PR changes target branch to 'ci' for 'github-actions' ecosystem of Dependabot.